### PR TITLE
Fix cancellation of orders

### DIFF
--- a/btoandav20/stores/oandav20store.py
+++ b/btoandav20/stores/oandav20store.py
@@ -699,12 +699,17 @@ class OandaV20Store(with_metaclass(MetaSingleton, object)):
             if oref is None:
                 break
 
-            oid = self._orders.get(oref, None)
+            oid = None
+            for key, value in self._orders.items():
+                if value == oref:
+                    oid = key
+                    break
+            
             if oid is None:
                 continue  # the order is no longer there
             try:
                 # TODO either close pending orders or filled trades
-                response = self.oapi.trade.close(self.p.account, oid)
+                response = self.oapi.order.cancel(self.p.account, oid)
             except Exception as e:
                 self.put_notification("{}: {}".format(
                     e,


### PR DESCRIPTION
Cancel order is not working. There are 2 bugs that are fixed in this PR:

- To get the Oanda ID (oid) by Backtraders oref you have to look at the values of self._orders, not the keys. The format of self._orders is ('oid', 'oref') not the other way around.
- Use order.cancel API call in stead of trade.close.